### PR TITLE
libs/php_ftp.o をコンパイするときのエラーに対応する。

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:fpm
 COPY ./php.ini /usr/local/etc/php/conf.d/
 RUN apt-get update \
-  && apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng12-dev libmcrypt-dev \
+  && apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng12-dev libmcrypt-dev libssl-dev \
   && docker-php-ext-install pdo_mysql mysqli mbstring gd iconv mcrypt json ftp zip


### PR DESCRIPTION
libs/php_ftp.o をコンパイするときに

/usr/src/php/ext/ftp/php_ftp.c:33:26: fatal error: openssl/ssl.h: No such file or directory
 # include <openssl/ssl.h>

でエラーしてしまうので、libssl-devパッケージを追加する。